### PR TITLE
build: update to 0.15.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v1
+        uses: mlugg/setup-zig@v2
         with:
           version: ${{ matrix.zig-version }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        zig-version: ["0.14.0"]
+        zig-version: ["0.15.2"]
         os: [macos-latest, windows-latest]
         include:
-          - zig-version: "0.14.0"
+          - zig-version: "0.15.2"
             os: ubuntu-latest
             check-format: true
 

--- a/build.zig
+++ b/build.zig
@@ -6,13 +6,14 @@ pub fn build(b: *std.Build) void {
 
     const upstream = b.dependency("protobuf_c", .{});
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "protobuf_c",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
     });
-
-    lib.linkLibC();
 
     lib.addCSourceFiles(.{
         .root = upstream.path("protobuf-c"),

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .protobuf_c,
     .fingerprint = 0x39094F755166B308,
     .version = "1.5.0",
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .protobuf_c = .{
             .url = "git+https://github.com/protobuf-c/protobuf-c?ref=v1.5.0#8c201f6e47a53feaab773922a743091eb6c8972a",


### PR DESCRIPTION
does what it says on the tin
tested locally on Fedora using the distro provided zig 0.15.2 and with a master build from ziglang.org