### PR TITLE
bump protobuf-c version to 1.5.2

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,12 +1,12 @@
 .{
     .name = .protobuf_c,
     .fingerprint = 0x39094F755166B308,
-    .version = "1.5.0",
+    .version = "1.5.2",
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .protobuf_c = .{
-            .url = "git+https://github.com/protobuf-c/protobuf-c?ref=v1.5.0#8c201f6e47a53feaab773922a743091eb6c8972a",
-            .hash = "N-V-__8AAGKbCgBaIPOO-yPY9ojdsggEeyYjVgjZ_eTITOMw",
+            .url = "git+https://github.com/protobuf-c/protobuf-c?ref=v1.5.2#4719fdd7760624388c2c5b9d6759eb6a47490626",
+            .hash = "N-V-__8AAOzKCgADWAaJ_5J9U3rotTnQCw0OBd-Qb3gL-8vW",
         },
     },
     .paths = .{


### PR DESCRIPTION
Looking at the diff, this is mostly changes to the code generator and not the runtime library, but it appears to have at least one fix for the runtime library included.

Making this PR to run CI because I am too lazy to update the workflow. Thank you github for the free CPU-hours.